### PR TITLE
Uppercase reads before passing to function kh.find_spectral_error_pos…

### DIFF
--- a/pipeline/report-errors-by-read.py
+++ b/pipeline/report-errors-by-read.py
@@ -85,7 +85,7 @@ def main():
     for n, record in enumerate(screed.open(args.sequences)):
         if n % 100000 == 0:
             print >>sys.stderr, '...', n
-        seq = record.sequence.replace('N', 'A')
+        seq = record.sequence.upper().replace('N', 'A')
 
         n_total += 1
 


### PR DESCRIPTION
in report-errors-by-read.py, I uppercased reads before passing them to kh.find_spectral_error_positions. It caused problems with small case "n" characters (they were not being replaced by "A").
